### PR TITLE
Feedback/email folders and keyboard

### DIFF
--- a/src/app/mail/dialogs/create-folder/create-folder.component.ts
+++ b/src/app/mail/dialogs/create-folder/create-folder.component.ts
@@ -5,7 +5,7 @@ import { AppState, MailBoxesState } from '../../../store/datatypes';
 import { Store } from '@ngrx/store';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { CreateFolder } from '../../../store/actions';
+import { UpdateFolder } from '../../../store/actions';
 
 @TakeUntilDestroy()
 @Component({
@@ -45,7 +45,7 @@ export class CreateFolderComponent implements OnInit, OnDestroy {
       this.mailBoxesState.mailboxes[0].folders = [];
     }
     this.mailBoxesState.mailboxes[0].folders.push(this.customFolderForm.value.folderName);
-    this.store.dispatch(new CreateFolder(this.mailBoxesState.mailboxes[0]));
+    this.store.dispatch(new UpdateFolder(this.mailBoxesState.mailboxes[0]));
   }
 
   onHide() {

--- a/src/app/mail/mail-sidebar/compose-mail/compose-mail.component.html
+++ b/src/app/mail/mail-sidebar/compose-mail/compose-mail.component.html
@@ -537,7 +537,9 @@
   <div class="modal-body bg-faded">
     <div class="mail-actions-form-holder modal-mail-actions-form-holder">
       <div class="form-group">
-        If you do not log into your account after this set time, the email will be sent
+          Email will be sent when timer expires. Logging into
+          your account resets the timer. This email can be
+          watched in the "Outbox" page.
       </div>
       <form (submit)="setDeadManTimerValue()">
         <div class="form-group">

--- a/src/app/mail/mail-sidebar/mail-sidebar.component.html
+++ b/src/app/mail/mail-sidebar/mail-sidebar.component.html
@@ -94,7 +94,12 @@
                 <li class="mailbox-sidebar-nav-item"  routerLinkActive="active" *ngFor="let folder of mailBoxesState.customFolders|slice:0:LIMIT; let i=index;">
                     <a routerLink="/mail/{{folder}}" class="mailbox-sidebar-nav-link">
                         <i class="folder-color-box icon is-success" [ngClass]="{'is-info': i%2 === 0, 'is-warning': i%3 === 0}"></i>
-                        <span class="mailbox-sidebar-nav-label text-capitalize" translate="mail_sidebar.trash">{{folder}}</span>
+                        <span class="mailbox-sidebar-nav-label text-capitalize">
+                            {{folder}}
+                            <button class="btn btn-link btn-sm float-right hover-icon px-1 py-0 text-white" (click)="showConfirmationModal(folder)">
+                                <i class="icon icon-cross icon-sm"></i>
+                            </button>
+                        </span>
                     </a>
                 </li>
                 <li class="mailbox-sidebar-nav-item" *ngIf="mailBoxesState?.customFolders?.length >= LIMIT">
@@ -132,3 +137,26 @@
 
 <!-- Mail compose dialog -->
 <app-compose-mail-dialog [isComposeVisible]="isComposeVisible" (hide)="isComposeVisible=false;"></app-compose-mail-dialog>
+
+
+<!-- TODO: refactor to stand alone component: LATER -->
+<!-- Confirm discard email modal -->
+<ng-template #confirmationModal let-c="close" let-d="dismiss">
+    <div class="modal-header">
+        <h3 class="modal-title w-100 text-dark"><strong>Confirm Delete</strong></h3>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close" (click)="d()">
+        <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+    <div class="modal-body bg-faded">
+        <div class="mail-actions-form-holder modal-mail-actions-form-holder">
+        <div class="form-group">
+            Are you sure, you want to delete this folder?
+        </div>
+        <div class="form-group text-right mb-0">
+            <button (click)="d()" class="btn btn-secondary btn-sm" role="button">Cancel</button>
+            <button (click)="deleteFolder()" class="btn btn-danger btn-sm" role="button" [disabled]="!mailState.loaded">Delete</button>
+        </div>
+        </div>
+    </div>
+</ng-template><!-- /.Confirm discard email modal ends -->

--- a/src/app/mail/mail-sidebar/mail-sidebar.component.html
+++ b/src/app/mail/mail-sidebar/mail-sidebar.component.html
@@ -117,7 +117,7 @@
                 <div class="text-white mt-1">43 MB</div>
             </div>
             <div class="mailbox-sidebar-footer-text hidden-in-sm">
-                <span translate="common.used_storage">Used storage</span>: {{settings?.used_storage | filesize}} of {{settings?.allocated_storage | filesize:'MB'}}</div>
+                <span translate="common.used_storage">Used storage</span>: {{(settings?.used_storage * 1024) | filesize}} of {{settings.allocated_storage}} MB</div>
             <a href="" class="btn-link text-white hidden-in-sm">
                 <small>
                     <u translate="common.upgrade_account">Upgrade account</u>

--- a/src/app/mail/mail-sidebar/mail-sidebar.component.ts
+++ b/src/app/mail/mail-sidebar/mail-sidebar.component.ts
@@ -6,7 +6,7 @@ import { OnDestroy, TakeUntilDestroy } from 'ngx-take-until-destroy';
 import { Observable } from 'rxjs/Observable';
 import { CreateFolderComponent } from '../dialogs/create-folder/create-folder.component';
 import { MailFolderType, Mail } from '../../store/models/mail.model';
-import { MoveMail } from '../../store/actions/mail.actions';
+import { MoveMail, UpdateFolder } from '../../store/actions/mail.actions';
 
 @TakeUntilDestroy()
 @Component({
@@ -104,9 +104,17 @@ export class MailSidebarComponent implements OnInit, OnDestroy {
     const folderMails: Mail[] = this.mailState.folders.get(this.selectedFolder);
     const ids = folderMails.map(mail => mail.id).join(',');
     if (ids) {
-      // Dispatch move to selected folder event
-      this.store.dispatch(new MoveMail({ ids, folder: MailFolderType.TRASH }));
+      this.mailBoxesState.mailboxes[0].folders = this.mailBoxesState.mailboxes[0].folders.filter(folder => folder !== this.selectedFolder);
+      this.store.dispatch(new MoveMail({
+        ids: ids,
+        folder: MailFolderType.TRASH,
+        shouldDeleteFolder: true,
+        mailbox: this.mailBoxesState.mailboxes[0]
+      }));
       this.confirmModalRef.dismiss();
+    } else {
+      this.mailBoxesState.mailboxes[0].folders = this.mailBoxesState.mailboxes[0].folders.filter(folder => folder !== this.selectedFolder);
+      this.store.dispatch(new UpdateFolder(this.mailBoxesState.mailboxes[0]));
     }
   }
 

--- a/src/app/mail/mail-sidebar/mail-sidebar.component.ts
+++ b/src/app/mail/mail-sidebar/mail-sidebar.component.ts
@@ -24,7 +24,7 @@ export class MailSidebarComponent implements OnInit, OnDestroy {
   public isComposeVisible: boolean = false;
   public settings: Settings;
   @ViewChild('confirmationModal') confirmationModal;
-  private confirmModalRef: NgbModalRef;
+  confirmModalRef: NgbModalRef;
 
   mailBoxesState: MailBoxesState;
   mailState: MailState;
@@ -111,11 +111,11 @@ export class MailSidebarComponent implements OnInit, OnDestroy {
         shouldDeleteFolder: true,
         mailbox: this.mailBoxesState.mailboxes[0]
       }));
-      this.confirmModalRef.dismiss();
     } else {
       this.mailBoxesState.mailboxes[0].folders = this.mailBoxesState.mailboxes[0].folders.filter(folder => folder !== this.selectedFolder);
       this.store.dispatch(new UpdateFolder(this.mailBoxesState.mailboxes[0]));
     }
+    this.confirmModalRef.dismiss();
   }
 
   ngOnDestroy(): void {

--- a/src/app/mail/mail.component.scss
+++ b/src/app/mail/mail.component.scss
@@ -310,6 +310,9 @@
   }
 
   .mailbox-sidebar-nav-label {
+    display: inline-block;
+    width: 100%;
+
     @include media("<ipad", ">sm") {
       display: none;
 
@@ -317,6 +320,20 @@
         display: block;
       }
     }
+  }
+}
+
+.mailbox-sidebar-nav-link{
+  .hover-icon{
+    min-width: unset;
+  }
+
+  .mailbox-sidebar-nav-label .hover-icon {
+    display: none;
+  }
+
+  &:hover  .mailbox-sidebar-nav-label .hover-icon  {
+    display: inline-block;
   }
 }
 

--- a/src/app/store/actions/mail.actions.ts
+++ b/src/app/store/actions/mail.actions.ts
@@ -24,8 +24,8 @@ export enum MailActionTypes {
   UNDO_DELETE_MAIL = '[Mail] UNDO DELETE DRAFT MAIL',
   UNDO_DELETE_MAIL_SUCCESS = '[Mail] UNDO DELETE DRAFT MAIL SUCCESS',
   SET_FOLDERS = '[MAILBOX] SET FOLDERS',
-  CREATE_FOLDER = '[MAILBOX] CREATE FOLDER',
-  CREATE_FOLDER_SUCCESS = '[MAILBOX] CREATE FOLDER SUCCESS',
+  UPDATE_FOLDER = '[MAILBOX] UPDATE FOLDER',
+  UPDATE_FOLDER_SUCCESS = '[MAILBOX] UPDATE FOLDER SUCCESS',
   SET_CURRENT_FOLDER = '[FOLDER] SET CURRENT',
   UPDATE_PGP_DECRYPTED_CONTENT = '[PGP] UPDATE PGP DECRYPTED CONTENT',
   UPDATE_CURRENT_FOLDER = '[FOLDER] UPDATE CURRENT FOLDER'
@@ -158,14 +158,14 @@ export class SetFolders implements Action {
   constructor(public payload: any) {}
 }
 
-export class CreateFolder implements Action {
-  readonly type = MailActionTypes.CREATE_FOLDER;
+export class UpdateFolder implements Action {
+  readonly type = MailActionTypes.UPDATE_FOLDER;
 
   constructor(public payload: any) {}
 }
 
-export class CreateFolderSuccess implements Action {
-  readonly type = MailActionTypes.CREATE_FOLDER_SUCCESS;
+export class UpdateFolderSuccess implements Action {
+  readonly type = MailActionTypes.UPDATE_FOLDER_SUCCESS;
 
   constructor(public payload: any) {}
 }
@@ -210,8 +210,8 @@ export type MailActions =
   | UndoDeleteMail
   | UndoDeleteMailSuccess
   | SetFolders
-  | CreateFolder
-  | CreateFolderSuccess
+  | UpdateFolder
+  | UpdateFolderSuccess
   | SetCurrentFolder
   | UpdatePGPDecryptedContent
   | UpdateCurrentFolder;

--- a/src/app/store/effects/mail.effects.ts
+++ b/src/app/store/effects/mail.effects.ts
@@ -14,8 +14,6 @@ import { catchError, switchMap } from 'rxjs/operators';
 import { MailService } from '../../store/services';
 // Custom Actions
 import {
-  CreateFolder,
-  CreateFolderSuccess,
   CreateMail,
   DeleteMailSuccess,
   GetMailDetail,
@@ -31,7 +29,7 @@ import {
   SnackPush,
   StarMailSuccess,
   UndoDeleteMail,
-  UndoDeleteMailSuccess
+  UndoDeleteMailSuccess, UpdateFolder, UpdateFolderSuccess
 } from '../actions';
 
 @Injectable()
@@ -60,16 +58,24 @@ export class MailEffects {
       return this.mailService.moveMail(payload.ids, payload.folder)
         .pipe(
           switchMap(res => {
-            return [
-              new MoveMailSuccess(payload),
-              new SnackPush({
-                message: `Mail moved to trash`,
-                ids: payload.ids,
-                folder: payload.folder,
-                sourceFolder: payload.sourceFolder,
-                mail: payload.mail
-              })
-            ];
+
+            const updateFolderActions = [];
+
+            if (payload.shouldDeleteFolder) {
+             updateFolderActions.push(new UpdateFolder(payload.mailbox));
+            }
+
+            updateFolderActions.push( new MoveMailSuccess(payload));
+            updateFolderActions.push( new SnackPush({
+              message: `Mail moved to trash`,
+              ids: payload.ids,
+              folder: payload.folder,
+              sourceFolder: payload.sourceFolder,
+              mail: payload.mail
+            }));
+
+            return updateFolderActions;
+
           }),
           catchError(err => [new SnackErrorPush({message: `Failed to move mail to ${payload.folder}.`})])
         );
@@ -137,15 +143,15 @@ export class MailEffects {
     });
 
   @Effect()
-  createFolderEffect: Observable<any> = this.actions
-    .ofType(MailActionTypes.CREATE_FOLDER)
-    .map((action: CreateFolder) => action.payload)
+  updateFolderEffect: Observable<any> = this.actions
+    .ofType(MailActionTypes.UPDATE_FOLDER)
+    .map((action: UpdateFolder) => action.payload)
     .switchMap(payload => {
-      return this.mailService.createFolder(payload)
+      return this.mailService.updateFolder(payload)
         .pipe(
           switchMap(res => {
             return [
-              new CreateFolderSuccess(res.folders)
+              new UpdateFolderSuccess(res.folders)
             ];
           }),
           catchError(err => [new SnackErrorPush({message: 'Failed to create folder.'})])

--- a/src/app/store/reducers/mailboxes.reducers.ts
+++ b/src/app/store/reducers/mailboxes.reducers.ts
@@ -50,13 +50,13 @@ export function reducer(state = initialState, action: MailActions): MailBoxesSta
         customFolders: action.payload,
       };
     }
-    case MailActionTypes.CREATE_FOLDER: {
+    case MailActionTypes.UPDATE_FOLDER: {
       return {
         ...state,
         inProgress: true,
       };
     }
-    case MailActionTypes.CREATE_FOLDER_SUCCESS: {
+    case MailActionTypes.UPDATE_FOLDER_SUCCESS: {
       return {
         ...state,
         customFolders: action.payload,

--- a/src/app/store/services/mail.service.ts
+++ b/src/app/store/services/mail.service.ts
@@ -51,7 +51,7 @@ export class MailService {
     return this.http.get<any>(`${apiUrl}emails/keys/?email__in=${emails}`).map(data => data['results']);
   }
 
-  createFolder(data: Mailbox): Observable<any> {
+  updateFolder(data: Mailbox): Observable<any> {
     return this.http.patch<any>(`${apiUrl}emails/mailboxes/${data.id}/`, data);
   }
 

--- a/src/app/users/users-sign-in/users-sign-in.component.ts
+++ b/src/app/users/users-sign-in/users-sign-in.component.ts
@@ -126,6 +126,7 @@ export class UsersSignInComponent implements OnDestroy, OnInit {
     this._keyboardRef.instance.attachControl(this.loginForm.controls['username']);
     this.usernameVC.nativeElement.focus();
     this.isKeyboardOpened = true;
+    this.prependCloseButtonToMatKeyboard();
   }
 
   openPasswordOSK() {
@@ -141,6 +142,7 @@ export class UsersSignInComponent implements OnDestroy, OnInit {
     this._keyboardRef.instance.attachControl(this.loginForm.controls['password']);
     this.passwordVC.nativeElement.focus();
     this.isKeyboardOpened = true;
+    this.prependCloseButtonToMatKeyboard();
   }
 
   closeKeyboard() {
@@ -160,10 +162,36 @@ export class UsersSignInComponent implements OnDestroy, OnInit {
     }
   }
 
+  private prependCloseButtonToMatKeyboard() {
+    const matKeyboardWrapper = document.getElementsByClassName('mat-keyboard-wrapper');
+    if (matKeyboardWrapper && this.checkIfCloseButtonExist()) {
+      const elChild = document.createElement('a');
+      elChild.setAttribute('id', 'close-mat-keyboard');
+      elChild.setAttribute('class', 'close-mat-keyboard');
+      elChild.innerHTML = '<i class="fa fa-times" id="close-mat-keyboard-icon"></i>';
+      // Prepend it to the parent element
+      matKeyboardWrapper[0].insertBefore(elChild, matKeyboardWrapper[0].firstChild);
+    }
+  }
+
+  private checkIfCloseButtonExist() {
+    return !document.getElementById('close-mat-keyboard')
+  }
+
   @HostListener('document:keydown', ['$event'])
   onKeydownHandler(event: KeyboardEvent) {
     if (event.keyCode === ESCAPE_KEYCODE) {
+      this.isKeyboardOpened = false;
       this.closeKeyboard();
     }
   }
+
+  @HostListener('document:click', ['$event'])
+  clickout(event) {
+    if (event.target.id === 'close-mat-keyboard' || event.target.id === 'close-mat-keyboard-icon') {
+      this.isKeyboardOpened = false;
+      this.closeKeyboard();
+    }
+  }
+
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -229,3 +229,27 @@ tag-input {
 .green{
   color: green;
 }
+
+.close-mat-keyboard{
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  border-radius: 50%;
+  border: 1px solid #333;
+  background: #333;
+  color: white;
+  height: 20px;
+  width: 20px;
+  text-align: center;
+  opacity: 1;
+
+  &:hover {
+    color: white;
+    opacity: 0.8;
+  }
+
+  .close-mat-keyboard-icon {
+    font-size: 12px;
+    vertical-align: middle;
+  }
+}


### PR DESCRIPTION
- handle sent to or received from in context to the mail folders selected
- show counters for email folders (context based) - draft and inbox for now
- disabled color selection while creating folder
- make `Select Message` dropdown in mail list header functional
- option to delete custom folder (move mails to trash folder)
- remove caret from contacts select dropdown
- update deadman's timer info text
- link deadman's, delayed or delete timer  properties with outbox mails 
- show total storage size as static size with filesize pipe
- add close button for mat keyboard



